### PR TITLE
Resurface Spring Boot Starter directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ DataStax Labs program.
 
 Refer to the [kafka-connector-cdc](kafka-connector-cdc) directory.
 
+### DataStax Spring Boot Starter
+*Note: DataStax is now contributing to the Pivotal/VMWare Spring Boot Starter for Cassandra which will replace this when released*
+
+Refer to the [spring-boot-starter](spring-boot-starter) directory
+
 ## Graduated Labs Components
 
 The following labs components have been promoted to GA and are no longer here:

--- a/spring-boot-starter/20190903/README-tests.md
+++ b/spring-boot-starter/20190903/README-tests.md
@@ -1,0 +1,147 @@
+# DataStax Java Driver Spring Boot Starter Test Module
+This test module can be used to assist in writing integration tests for projects that use the
+[DataStax Java Driver Spring Boot Starter]. It provides a framework that can spin up a test
+instance of Cassandra (using Docker or [CCM]) and automatically configures a Java Driver CqlSession
+object that can connect to the test container. It is primarily intended for writing Integration
+tests for situations where it is not possible or desirable to maintain a dedicated Cassandra DB.
+
+## Prerequisites
+In order to use this test module, you will have to have [Docker] and/or [CCM] installed. You can
+install both if you wish, and your can use both in your tests if you have them both installed.
+
+## Maven Coordinates
+To use this module in your application's tests, add the following to your Maven pom.xml:
+
+```xml
+<dependency>
+    <groupId>com.datastax.oss</groupId>
+    <artifactId>java-driver-spring-boot-starter-test</artifactId>
+    <scope>test</scope>
+    <version>1.0.0.20190903-LABS</version>
+</dependency>
+```
+
+## Test Cassandra Resources
+This module provides two types of Cassandra resources that can be automatically instantiated, as
+well as automatically configuring the `@Autowired` test Session so that it can successfully connect
+to the test Cassandra instance: Docker and [CCM]. For Docker, this project uses the [Testcontainers]
+project to manage the container from within Java code, so you only need Docker to be installed and
+running. For CCM, this project leverages the Datastax Java Driver test infrastructure project to
+manage your Cassandra test instances (see the [CCM] project for details).
+
+To write an integration test using either Docker or CCM, you need to extend one of the provided Base
+test classes and annotate your test appropriately.
+
+Container | Cassandra Version | Extend Base Test Class
+----------|-------------------|----------------
+[Docker][docker package] | Cassandra 2.1 | com.datastax.oss.spring.configuration.docker.Cassandra21DockerRuleTestBase
+[Docker][docker package] | Cassandra 2.2 | com.datastax.oss.spring.configuration.docker.Cassandra22DockerRuleTestBase
+[Docker][docker package] | Cassandra 3.0 | com.datastax.oss.spring.configuration.docker.Cassandra30DockerRuleTestBase
+[Docker][docker package] | Cassandra 3.11 | com.datastax.oss.spring.configuration.docker.Cassandra311DockerRuleTestBase
+[CCM][CcmSpringRuleTestBase] | (any version) | com.datastax.oss.spring.configuration.ccm.CcmSpringRuleTestBase
+
+Once you have chosen the base test class to extend, you need to specify a few test annotations.
+
+### Integration Test Annotations
+For your Spring Boot Test class, you will need to annotate your test with Spring's `SpringRunner`
+class as the JUnit Runner. You will also need to add Springs's `@SpringBootTest` annotation and
+specify the following classes:
+1. The Datastax Java Driver Spring Boot starter configuration class
+1. The [AdminSessionHook] class ([TestKeyspaceCreator]) that will create your application's Keyspace
+   _or_ your own implementation (see [Creating the Test Keyspace](#creating-the-test-keyspace))
+1. Your own application's Spring Boot main class.
+
+Example test class using Docker to provide Cassandra 3.11:
+```java
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+  classes = {TestKeyspaceCreator.class,
+      DriverAutoConfiguration.class,
+      MyApplication.class}
+)
+public class MyApplicationTest extends Cassandra311DockerRuleTestBase {
+  // tests
+}
+```
+Example test class using CCM:
+```java
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+  classes = {TestKeyspaceCreator.class,
+      DriverAutoConfiguration.class,
+      MyApplication.class}
+)
+public class MyApplicationTest extends CcmSpringRuleTestBase {
+  // tests
+}
+```
+### Creating the Test Keyspace
+Since testing with this module is using dynamic Cassandra instances, the keyspace for your
+application will not exist in the Cassandra container at startup. This presents a small problem when
+Spring tries to create the CqlSession bean in your application code as it will fail to initialize if
+the keyspace does not exist. To fix this problem, the Datastax Java Driver Spring Boot Starter has
+an [AdminSessionHook] interface that you can implement to execute database setup steps that only
+need to happen once during application startup.
+
+This module provides an [AdminSessionHook] implementation, [TestKeyspaceCreator]. If your test class
+includes this in the `@SpringBootTest` annotation class list, it will create the keyspace specified
+in your Spring environment (`datastax-java-driver.basic.session-keyspace`) as soon as the Cassandra
+test instance is spun up. The implementation uses a special _admin session_ that has no keyspace
+configuration so that it can be initialized for this purpose.
+
+You can provide your own implementation of [AdminSessionHook] if you wish. If your provided hook is
+able to create your application's keyspace, you don't have to include [TestKeyspaceCreator] in your
+tests. You can provide multiple hook implementations as well, however you should **pay special
+attention to the ordering of the hooks/classes specified**.
+
+## Test Session Configuration
+The majority of the Session configuration will likely be inherited from your Spring
+`application.yml` in your application's resources. When testing in different environments, some of
+the Session settings will need to be overridden to match the environment (i.e. `qa`, `integeration`,
+etc). The differences are usually configured in Spring profiles (i.e. `application-qa.yml`,
+`application-integration.yml`, etc). However, there are two Driver configuration settings that must
+**NOT** be overridden for integration testing using this module: Contact Points and Local
+Datacenter.
+
+### Contact Points and Local Datacenter Configuration
+In order for the Spring `@Autowired` Driver Session object to be correctly instantiated for testing,
+it has to be configured with the correct Contact Points and Local Datacenter for the Cassandra
+cluster being tested against. Since this module spins up Cassandra dynamically, these values are set
+in the framework by activating the [integration-cassandra] Spring profile which determines them at
+runtime. It looks like this:
+
+```yaml
+datastax-java-driver:
+  basic.contact-points:
+    - 127.0.0.1:${cassandra-port}
+  basic.load-balancing-policy:
+    local-datacenter: ${cassandra-datacenter}
+```
+The `cassandra-port` and `cassandra-datacenter` values are populated by Spring when the tests are
+executed. Again, this is done using Spring profile activation ([integration-cassandra]), so you
+**MUST NOT**:
+1. Specify `datastax-java-driver.basic.contact-points` in any Spring profiles that are **activated
+   during tests** (see NOTE below)
+1. Specify `datastax-java-driver.basic.load-balancing-policy.local-datacenter` in any Spring
+   profiles that are **activated during tests** (see NOTE below)
+1. Create your own `application-integration-cassandra.yml` or
+   `application-integration-cassandra.properties` Spring profile.
+
+NOTE: Spring profiles that are activated during tests include any profiles (YAML files or Properties
+files) used in Spring's `@ActiveProfiles` annotations, or any profiles that may be activated on the
+command line using `-Dspring.profiles.active`.
+
+It is fine (and expected) that you would have these values provided/overridden in your normal
+`application.yml`, or any production specific Spring profiles (ex `application-prod.yml`). Regular
+production profile values are overridden by test profiles during integration tests. The restrictions
+only apply to Spring profiles that are activated specifically for tests.
+
+[DataStax Java Driver Spring Boot Starter]: ../
+[Docker]: https://docs.docker.com/install/
+[CCM]: https://github.com/riptano/ccm
+[Testcontainers]: https://www.testcontainers.org/
+[docker package]: src/main/java/com/datastax/oss/spring/configuration/docker
+[TestKeyspaceCreator]: src/main/java/com/datastax/oss/spring/configuration/TestKeyspaceCreator.java
+[CcmSpringRuleTestBase]: src/main/java/com/datastax/oss/spring/configuration/ccm/CcmSpringRuleTestBase.java
+[integration-cassandra]: src/main/resources/application-integration-cassandra.yml
+[AdminSessionHook]: ../#admin-session

--- a/spring-boot-starter/20190903/README.md
+++ b/spring-boot-starter/20190903/README.md
@@ -1,0 +1,244 @@
+# DataStax Java Driver Spring Boot Starter
+This Spring Boot Starter can be used for configuring and injecting a Datastax Java Driver Session
+into a Spring Boot application. Simply include the jarfile with your application and use Spring's
+`@Autowired` annotation (or `@javax.inject.Inject`) to inject the desired Java Driver Beans provided
+by this module.
+
+## DataStax Labs Installation
+These are the instructions for installing and using the DataStax Java
+Driver Spring Boot Labs preview.
+
+For the downloadable tarball version of the Spring Boot Starter
+preview, refer to the [DataStax Labs] website and download DataStax
+Java Driver Spring Boot Starter. To install from the bundle:
+
+1. Download and extract the bundle
+2. Using a console/terminal, change into the extracted location
+3. Execute the `install_maven.sh` script in the extracted location
+   ```sh
+   > cd datastax-java-driver-spring-boot-starter-1.0.0.20190903-LABS
+   > ./install_maven.sh
+   ```
+
+This will install all of the Spring Boot Starter artifacts into your local Maven repository so that
+you can build your own Spring Boot applications with the snippets below. See the README.md in the
+demo directory for more on the demo project using this Spring Boot Starter. See the README-tests.md
+for more on integration testing with the Spring Boot Starter.
+
+The use of the software described here is subject to the
+[DataStax Labs Terms].
+
+## Maven Coordinates
+To include this module in a Maven project, add the dependency in your application's POM file:
+
+```xml
+  <dependencies>
+    <dependency>
+      <groupId>com.datastax.oss</groupId>
+      <artifactId>java-driver-spring-boot-starter</artifactId>
+      <version>1.0.0.20190903-LABS</version>
+    </dependency>
+  </dependencies>
+```
+
+## Injecting Java Driver Session Bean
+To inject an instance of a Driver Session into you application, simply use Spring's `@Autowired`
+annotation in your Spring components and services:
+
+```java
+@Component
+public class MyService {
+
+  @Autowired
+  private CqlSession cqlSession;
+
+  public ResultSet execute(String query) {
+    return cqlSession.execute(query);
+  }
+}
+```
+or use the JSR330 `@Inject` annotation:
+```java
+@Component
+public class MyService {
+
+  @Inject
+  private CqlSession cqlSession;
+
+  public ResultSet execute(String query) {
+    return cqlSession.execute(query);
+  }
+}
+```
+
+## Configuring The Driver
+With no additional configuration, Spring will create a driver Session configured with driver
+defaults. You can read more about [driver configuration][Driver Config Docs], and more about
+[driver configuration defaults][Default Driver Config Reference Docs]. In most cases, you
+will want to change some of the default values to match your environment (for example, contact
+points, keyspace, local datacenter, etc).
+
+### Override Driver Defaults
+Using Spring's [external configuration][Spring Externalized Configuration], it is possible to set
+custom values for any driver configuration parameters you may need to override in your application.
+For a simple example, if you want to change the default local datacenter, you could use the
+following `application.properties` in your application:
+
+```properties
+datastax-java-driver.basic.load-balancing-policy.local-datacenter = Cassandra
+```
+The same override could be made in `application.yml`:
+```yaml
+datastax-java-driver:
+  basic.load-balancing-policy:
+    local-datacenter: Cassandra
+```
+The property keys need to match the driver configuration keys in order to be used. All driver
+property overrides must start with `datastax-java-driver`, and use the `.` character as a _path_
+separator. Again, these match the property names in the
+[driver configuration reference][Default Driver Config Reference Docs]. You only have to provide
+values for things you wish to override.
+
+#### Overriding List Values
+Overriding List values in `application.properties` requires you to use numbered indexes for the
+property name. This is to avoid the ambiguity of the value being a single value with a comma in the
+value as opposed to a comma-separated list value. For example, setting contact points would look
+like this:
+
+```properties
+datastax-java-driver.basic.contact-points[0] = 127.0.0.1:9042
+datastax-java-driver.basic.contact-points[1] = 127.0.0.2:9042
+```
+For YML configuration, it's more straightforward as you can use the standard YML list syntax:
+```yaml
+datastax-java-driver:
+  basic.contact-points:
+    - 127.0.0.1:9042
+    - 127.0.0.2:9042
+```
+
+### Override examples
+See [application.properties.example][example properties file override] as an example of a properties
+file and [application.yml.example][example yml file override] as an example of a YML file.
+
+### Spring Profiles
+You can also make use of [Spring Profiles][Spring Boot Profile Docs] in your application, putting
+common configuration properties in `application.properties` (or `application.yml`) and deployment
+specific configuration in other profiles.
+
+#### Create Driver Configuration Overrides for "Dev" and "QA"
+If you have a `dev` environment with different contact points than your `qa` environment, but both
+share the same local datacenter name, you can have this in `application.properties`:
+
+```properties
+datastax-java-driver.basic.load-balancing-policy.local-datacenter = Cassandra
+```
+
+this in `application-dev.properties`:
+```properties
+datastax-java-driver.basic.contact-points[0] = 127.0.0.1:9042
+datastax-java-driver.basic.contact-points[1] = 127.0.0.2:9042
+```
+
+and this in `application-qa.properties`:
+```properties
+datastax-java-driver.basic.contact-points[0] = 10.0.1.1:9042
+datastax-java-driver.basic.contact-points[1] = 10.0.1.2:9042
+```
+
+When running your application, the contact points used by the driver would be determined by which
+profile is active. Also, remember that if properties exist in `application.properties` as well as
+an active Spring profile, the profile values will take precedence. See
+[Spring's documentation][Spring Externalized Configuration] for precedence order.
+
+#### Spring Profile Caveats and Driver Execution Profiles
+1. If you enable multiple Spring profiles, and more than one profile defines a property, the last
+one activated wins. Using the above example, if you run your application like this:
+   ```sh
+   java -Dspring.profiles.active=dev,qa myApplication.jar
+   ```
+   The Driver Session bean will use the contact points in `application-qa.properties`.
+   ```sh
+   java -Dspring.profiles.active=qa,dev myApplication.jar
+   ```
+   If you change the order of the active profiles, the Driver Session bean will use the contact
+   points in `application-dev.properties`.
+
+1. Spring profiles are not the same as, and do not map to,
+[Driver Execution Profiles][Driver Execution Profile Docs]. Driver Execution Profiles are fully
+supported and can be defined in any Spring properties files. Any driver configuration that you want
+to set in a driver execution profile will just need `profiles` and the profile name as _paths_ in
+the property name. For example, if you want a **slow** profile that increases request timeouts from
+2 seconds (the default) to 30 seconds, put this in `application.properties`:
+   ```properties
+   datastax-java-driver.profiles.slow.basic.request.timeout = 30 seconds
+   ```
+   The general format for driver execution profile configuration of property **someProp** is:
+   ```properties
+   datastax-java-driver.profiles.myProfile.someProp = <profile specific value>
+   ```
+   where **myProfile** is your execution profile name and **someProp** is whatever driver property
+   you want to change within the execution profile.
+
+## Admin Session
+Sometimes it is necessary to setup your Cassandra database before your application starts performing
+its normal operations. An example of this would be creating the keyspace that your application will
+use if it doesn't already exist. If you try to create a `CqlSession` that has a configured keyspace,
+and the keyspace doesn't exist, the session will fail to be instantiated. To handle this, there is
+an _admin session_ that is created with the same Spring configuration that your application will
+use, but without a keyspace configured. This will allow the _admin session_ to connect where the
+normal application session would fail.
+
+The _admin session_ performs any defined admin operations that are provided as `AdminSessionHook`
+implementations. The API for the Hook simply has one method:
+
+```java
+void executeOnAdminSession(CqlSession cqlSession)
+```
+
+As long as your implementations of this interface are picked up via Spring's Component scan, they
+will be added to the `DriverAutoConfiguration` and invoked as soon as the _admin session_ is
+created. An example of setting up your application's keyspace using this hook would be:
+
+```java
+@Component
+public class KeyspaceCreator implements AdminSessionHook {
+
+  // Get the application keyspace from Spring config
+  @Value("${datastax-java-driver.basic.session-keyspace}")
+  private String keysapce;
+
+  @Override
+  public void executeOnAdminSession(CqlSession cqlSession) {
+    // create the keyspace when the hook is invoked
+    cqlSession.execute(
+        String.format(
+            "CREATE KEYSPACE IF NOT EXISTS %s "
+                + "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}",
+            keysapce));
+  }
+}
+```
+
+It is not possible to inject the _admin session_ directly into your application or tests.
+Interaction with the _admin session_ can only be done through the `AdminSessionHook` interface.
+
+When implementing `AdminSessionHook` keep in mind the following guidelines:
+
+1. Your implementation should perform the necessary operations synchronously. If you really need
+to dispatch operations asynchronously, make sure that all of them are properly terminated when
+the call to the `executeOnAdminSession` method returns, because the admin session is closed 
+immediately after all the hooks are executed.
+2. Your implementation should not throw; if a `RuntimeException` is thrown from 
+`executeOnAdminSession`, that exception will be caught and logged at `ERROR` level along with its
+stack trace, then the execution flow will skip to the next hook.
+
+[Driver Config Docs]: https://docs.datastax.com/en/developer/java-driver/4.1/manual/core/configuration/
+[Default Driver Config Reference Docs]: https://docs.datastax.com/en/developer/java-driver/4.1/manual/core/configuration/reference/
+[Spring Externalized Configuration]: https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html
+[Spring Boot Profile Docs]: https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-profile-specific-properties
+[Driver Execution Profile Docs]: https://docs.datastax.com/en/developer/java-driver/4.1/manual/core/configuration/#execution-profiles
+[example properties file override]: starter/src/main/resources/application.properties.example
+[example yml file override]: starter/src/main/resources/application.yml.example
+[DataStax Labs]: https://downloads.datastax.com/#labs
+[DataStax Labs Terms]: https://www.datastax.com/terms/datastax-labs-terms

--- a/spring-boot-starter/20190903/demo/.gitignore
+++ b/spring-boot-starter/20190903/demo/.gitignore
@@ -1,0 +1,29 @@
+HELP.md
+/target/
+!.mvn/wrapper/maven-wrapper.jar
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+/build/
+
+### VS Code ###
+.vscode/

--- a/spring-boot-starter/20190903/demo/README.md
+++ b/spring-boot-starter/20190903/demo/README.md
@@ -1,0 +1,164 @@
+# DataStax Java Driver Spring Demo
+This is a demo project that is using DataStax Java Driver Spring Boot Starter together with DataStax
+[ObjectMapper]. It uses Spring Starter by importing the dependency:
+
+```xml
+<dependency>
+    <groupId>com.datastax.oss</groupId>
+    <artifactId>java-driver-spring-boot-starter</artifactId>
+    <version>1.0.0.20190903-LABS</version>
+</dependency>
+```
+Thanks to the starter mechanism, the `CqlSession` is automatically created. It can be injected by using Spring `@Autowired`:
+
+```java
+@Autowired CqlSession cqlSession
+```
+
+## Prerequisites
+This demo application has one prerequisite: running Cassandra on localhost.
+If you wish to connect to a Cassandra instance that is remote, or is not bound to localhost, please alter the
+application.yml cassandra configuration:
+
+```yaml
+datastax-java-driver:
+  basic.contact-points:
+    - 127.0.0.1:9042
+  basic.session-keyspace: test
+  basic.load-balancing-policy:
+    local-datacenter: datacenter1
+```
+
+**IMPORTANT: Pay special attention to the Driver configuration here, in particular to the contact points
+and the local datacenter name. Ensure that your Cassandra instance is accessible at the contact points
+you provide, and that the local datacenter name matches.**
+
+## How to start the Demo App
+
+To start the Demo Application run the [maven] command:
+
+`mvn spring-boot:run`
+
+Remember that you need to have running Cassandra instance on your localhost (see [Prerequisites](#Prerequisites) section)
+
+## Object Mapper
+The application is using DataStax Object Mapper to map product entity from cql to java objects.
+To make it work this dependency is needed:
+```xml
+<dependency>
+    <groupId>com.datastax.oss</groupId>
+    <artifactId>java-driver-mapper-processor</artifactId>
+    <version>${datastax.java.driver.version}</version>
+</dependency>
+```
+
+Object Mapper is mapping Product table: `product(id int PRIMARY KEY, description text)` to Product Entity:
+
+```java
+@Entity
+public class Product {
+
+  @PartitionKey private Integer id;
+  private String description;
+
+  public Product() {}
+
+  public Product(Integer id, String description) {
+    this.id = id;
+    this.description = description;
+  }
+  // getters and setters omitted
+}
+```
+
+The generated `ProductDao` is constructed and injected into Spring DI container by `MapperConfiguration` class.
+
+## AdminSessionHook Mechanism
+This application is using the [AdminSessionHook] mechanism to provide an automatic way of creating
+the`test` keyspace and the `product` table that are used by the `ProductDao` interface.
+
+The `KeyspaceTableInitHook` class is performing keyspace and table initialization inside the
+`executeOnAdminSession` callback.
+
+This logic is executed on the special admin CQL session (a session without keyspace explicitly set)
+and is guaranteed to be executed _before_ the main `cqlSession` bean is initialized (see
+[AdminSessionHook documentation][AdminSessionHook]).
+
+## REST API
+The REST API is exposed by the `ProductController`.
+You can send requests to exercise the API using curl with the following commands:
+
+```bash
+# create an entity
+curl -d '{"id":1, "description":"i was created by curl"}' -H "Content-Type: application/json" -X POST http://localhost:8080/product/
+
+# retrieve
+curl -X GET http://localhost:8080/product/1
+
+# delete
+curl -X DELETE http://localhost:8080/product/1
+
+# retrieve - NOT_FOUND
+curl -X GET http://localhost:8080/product/1
+```
+
+Please note that `ProductController` is exposing `Product` entity by mapping it to `ProductDto` - it is important to not expose
+Entity by the REST API directly if you want to evolve `Product` entity class independently from your API.
+
+## Testing
+The DataStax Spring Boot starter provides an [integration test module] that ships with embedded Cassandra that could be used in integration tests out of the box.
+To use it you need to add the following dependency to your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>com.datastax.oss</groupId>
+    <artifactId>java-driver-spring-boot-starter-test</artifactId>
+    <version>${datastax.java.driver.spring.version}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+The starter provides its own [AdminSessionHook] that is able to create the keyspace specified as the
+`datastax-java-driver.basic.session-keyspace` setting in your `application.yml` file
+(see spring documentation about inheriting settings from properties files).
+
+To see the usage of this automatic hook in an integration test that exercises the REST API see the [ProductControllerIT]
+(note that the `classes` attribute with explicit `TestKeyspaceCreator.class` was added):
+
+```java
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+  classes = {TestKeyspaceCreator.class, DriverAutoConfiguration.class, MainApplication.class},
+  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+public class ProductControllerIT extends CcmSpringRuleTestBase {
+```
+
+If you have your own hook that creates test keyspace you can use it instead (for example `KeyspaceTableInitHook`).
+
+## Profiles in Tests
+If you want to provide your own profile for the purpose of integration testing you can use `@ActiveProfiles("integration")`:
+
+```java
+@ActiveProfiles("integration")
+public class ProductServiceIT extends CcmSpringRuleTestBase {
+```
+
+NOTE: Any settings defined in `application-integration.yml` will override the same settings in your `application.yml`
+(see [ProductServiceIT]`#should_load_settings_from_integration_profile` test).
+
+## Packages in the demo project:
+- api: Contains the DTO (Data Transfer Object) classes used by the API
+- controller: Contains the controller that are exposing DTOs via REST API.
+- mapper: All classes needed for Java Driver Object Mapper. It contains `@Mapper`, `@Dao`, and `@Entity`.
+- persistence:  Provides a `ProductDao` bean that is injected into the Spring DI Container.
+                Contains an implementation of `AdminSessionHook` with keyspace and table initialization.
+- service: Contains ProductService that performs the mapping from Entity to DTO.
+           It has also the `@ConfigurationProperties` `@Component` that demonstrates loading custom setting from `application.yml`.
+
+[ObjectMapper]: https://docs.datastax.com/en/developer/java-driver/4.1/manual/mapper/
+[ProductControllerIT]: src/test/java/com/datastax/oss/spring/demo/controller/ProductControllerIT.java
+[ProductServiceIT]: src/test/java/com/datastax/oss/spring/demo/service/ProductServiceIT.java
+[AdminSessionHook]: ../README.md#admin-session
+[integration test module]: ../test-infra
+[maven]: https://maven.apache.org/

--- a/spring-boot-starter/20190903/demo/pom.xml
+++ b/spring-boot-starter/20190903/demo/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The use of the software described here is subject to the DataStax Labs Terms
+    [https://www.datastax.com/terms/datastax-labs-terms]
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.3.0.M3</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.datastax.oss</groupId>
+    <artifactId>java-driver-spring-boot-starter-demo</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>DataStax Java driver Spring Boot Starter - Demo</name>
+    <description>Spring Autoconfigure project for DataStax Java Driver - Demo</description>
+
+    <properties>
+        <java.version>1.8</java.version>
+        <datastax.java.driver.version>4.5.0</datastax.java.driver.version>
+        <coveo.fmt.version>2.2.0</coveo.fmt.version>
+        <mycila.version>3.0</mycila.version>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>spring-milestone</id>
+            <name>Spring Milestone Repository</name>
+            <url>https://repo.spring.io/milestone</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.datastax.oss</groupId>
+            <artifactId>java-driver-mapper-processor</artifactId>
+            <version>${datastax.java.driver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-cassandra</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.coveo</groupId>
+                    <artifactId>fmt-maven-plugin</artifactId>
+                    <version>${coveo.fmt.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${mycila.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.2.5.RELEASE</version>
+            </plugin>
+            <plugin>
+                <groupId>com.coveo</groupId>
+                <artifactId>fmt-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/MainApplication.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/MainApplication.java
@@ -1,0 +1,16 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MainApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(MainApplication.class, args);
+  }
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/api/ProductDto.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/api/ProductDto.java
@@ -1,0 +1,38 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.api;
+
+public class ProductDto {
+  private Integer id;
+  private String description;
+
+  public ProductDto() {}
+
+  public ProductDto(Integer id, String description) {
+    this.id = id;
+    this.description = description;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public String toString() {
+    return "ProductDto{" + "id=" + id + ", description='" + description + '\'' + '}';
+  }
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/api/package-info.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/api/package-info.java
@@ -1,0 +1,6 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+/** This package contains the DTO (Data Transfer Object) classes used by the API. */
+package com.datastax.oss.spring.demo.api;

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/controller/ProductController.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/controller/ProductController.java
@@ -1,0 +1,46 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.controller;
+
+import com.datastax.oss.spring.demo.api.ProductDto;
+import com.datastax.oss.spring.demo.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/product")
+public class ProductController {
+  private ProductService productService;
+
+  @Autowired
+  public ProductController(ProductService productService) {
+    this.productService = productService;
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<ProductDto> getProduct(@PathVariable final int id) {
+    return productService
+        .getProduct(id)
+        .map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
+  }
+
+  @PostMapping(value = "/", consumes = "application/json")
+  public boolean addProduct(@RequestBody ProductDto productDto) {
+    return productService.saveProduct(productDto);
+  }
+
+  @DeleteMapping("/{id}")
+  public boolean deleteProduct(@PathVariable final int id) {
+    return productService.deleteProduct(id);
+  }
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/controller/package-info.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/controller/package-info.java
@@ -1,0 +1,6 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+/** This package contains the controller that are exposing DTOs via REST API. */
+package com.datastax.oss.spring.demo.controller;

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/mapper/InventoryMapper.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/mapper/InventoryMapper.java
@@ -1,0 +1,16 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.mapper;
+
+import com.datastax.oss.driver.api.core.CqlIdentifier;
+import com.datastax.oss.driver.api.mapper.annotations.DaoFactory;
+import com.datastax.oss.driver.api.mapper.annotations.DaoKeyspace;
+import com.datastax.oss.driver.api.mapper.annotations.Mapper;
+
+@Mapper
+public interface InventoryMapper {
+  @DaoFactory
+  ProductDao productDao(@DaoKeyspace CqlIdentifier keyspace);
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/mapper/Product.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/mapper/Product.java
@@ -1,0 +1,38 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.mapper;
+
+import com.datastax.oss.driver.api.mapper.annotations.Entity;
+import com.datastax.oss.driver.api.mapper.annotations.PartitionKey;
+
+@Entity
+public class Product {
+
+  @PartitionKey private Integer id;
+  private String description;
+
+  public Product() {}
+
+  public Product(Integer id, String description) {
+    this.id = id;
+    this.description = description;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/mapper/ProductDao.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/mapper/ProductDao.java
@@ -1,0 +1,23 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.mapper;
+
+import com.datastax.oss.driver.api.mapper.annotations.Dao;
+import com.datastax.oss.driver.api.mapper.annotations.Delete;
+import com.datastax.oss.driver.api.mapper.annotations.Insert;
+import com.datastax.oss.driver.api.mapper.annotations.Select;
+import java.util.Optional;
+
+@Dao
+public interface ProductDao {
+  @Select
+  Optional<Product> findById(Integer productId);
+
+  @Insert
+  boolean save(Product product);
+
+  @Delete(entityClass = Product.class)
+  boolean delete(Integer productId);
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/mapper/package-info.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/mapper/package-info.java
@@ -1,0 +1,6 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+/** All classes needed for Java Driver Object Mapper. It contains @Mapper, @Dao, and @Entity. */
+package com.datastax.oss.spring.demo.mapper;

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/persistence/MapperConfiguration.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/persistence/MapperConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.persistence;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.spring.demo.mapper.InventoryMapper;
+import com.datastax.oss.spring.demo.mapper.InventoryMapperBuilder;
+import com.datastax.oss.spring.demo.mapper.ProductDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MapperConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MapperConfiguration.class);
+
+  @Bean
+  public InventoryMapper inventoryMapper(@Autowired CqlSession cqlSession) {
+    LOGGER.trace("create inventoryMapper");
+    return new InventoryMapperBuilder(cqlSession).build();
+  }
+
+  @Bean
+  public ProductDao productDao(
+      @Autowired CqlSession cqlSession, @Autowired InventoryMapper inventoryMapper) {
+    LOGGER.trace("create ProductDao");
+    if (!cqlSession.getKeyspace().isPresent()) {
+      throw new MapperInitializationException(
+          String.format("keyspace on session: %s was not set", cqlSession.getName()));
+    }
+    return inventoryMapper.productDao(cqlSession.getKeyspace().get());
+  }
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/persistence/MapperInitializationException.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/persistence/MapperInitializationException.java
@@ -1,0 +1,11 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.persistence;
+
+public class MapperInitializationException extends RuntimeException {
+  public MapperInitializationException(String msg) {
+    super(msg);
+  }
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/persistence/package-info.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/persistence/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+/**
+ * Provides a ProductDao bean that is injected into the Spring DI Container. Contains an
+ * implementation of AdminSessionHook with keyspace and table initialization.
+ */
+package com.datastax.oss.spring.demo.persistence;

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/service/MainAppSettings.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/service/MainAppSettings.java
@@ -1,0 +1,22 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.service;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "your-setting")
+public class MainAppSettings {
+  private String a;
+
+  public String getA() {
+    return a;
+  }
+
+  public void setA(String a) {
+    this.a = a;
+  }
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/service/ProductService.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/service/ProductService.java
@@ -1,0 +1,48 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+package com.datastax.oss.spring.demo.service;
+
+import com.datastax.oss.spring.demo.api.ProductDto;
+import com.datastax.oss.spring.demo.mapper.Product;
+import com.datastax.oss.spring.demo.mapper.ProductDao;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProductService.class);
+
+  private ProductDao productDao;
+
+  @Autowired
+  public ProductService(ProductDao productDao, MainAppSettings setting) {
+    this.productDao = productDao;
+    LOGGER.trace("Starting service with setting: {}", setting.getA());
+  }
+
+  public Optional<ProductDto> getProduct(int id) {
+    return productDao.findById(id).map(this::mapToDto);
+  }
+
+  private ProductDto mapToDto(Product product) {
+    return new ProductDto(product.getId(), product.getDescription());
+  }
+
+  public boolean saveProduct(ProductDto productDto) {
+    return productDao.save(mapToEntity(productDto));
+  }
+
+  private Product mapToEntity(ProductDto productDto) {
+    return new Product(productDto.getId(), productDto.getDescription());
+  }
+
+  public boolean deleteProduct(int id) {
+    return productDao.delete(id);
+  }
+}

--- a/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/service/package-info.java
+++ b/spring-boot-starter/20190903/demo/src/main/java/com/datastax/oss/spring/demo/service/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * The use of the software described here is subject to the DataStax Labs Terms
+ * [https://www.datastax.com/terms/datastax-labs-terms]
+ */
+/**
+ * Contains ProductService that performs the mapping from Entity to DTO. It has also
+ * the @ConfigurationProperties @Component that demonstrates loading custom setting from
+ * application.yml.
+ */
+package com.datastax.oss.spring.demo.service;

--- a/spring-boot-starter/20190903/demo/src/main/resources/application.yml
+++ b/spring-boot-starter/20190903/demo/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+#
+# The use of the software described here is subject to the DataStax Labs Terms
+# [https://www.datastax.com/terms/datastax-labs-terms]
+#
+
+datastax-java-driver:
+  basic.contact-points:
+    - 127.0.0.1:9042
+  basic.session-keyspace: test
+  basic.load-balancing-policy:
+    local-datacenter: datacenter1
+
+your-setting:
+  a: "value"

--- a/spring-boot-starter/20190903/demo/src/main/resources/curl_product_api.sh
+++ b/spring-boot-starter/20190903/demo/src/main/resources/curl_product_api.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# The use of the software described here is subject to the DataStax Labs Terms
+# [https://www.datastax.com/terms/datastax-labs-terms]
+#
+
+# create an entity
+curl -d '{"id":1, "description":"i was created by curl"}' -H "Content-Type: application/json" -X POST http://localhost:8080/product/
+
+# retrieve
+curl -X GET http://localhost:8080/product/1
+
+# delete
+curl -X DELETE http://localhost:8080/product/1
+
+# retrieve - NOT_FOUND
+curl -X GET http://localhost:8080/product/1

--- a/spring-boot-starter/20190903/demo/src/main/resources/logback.xml
+++ b/spring-boot-starter/20190903/demo/src/main/resources/logback.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    The use of the software described here is subject to the DataStax Labs Terms
+    [https://www.datastax.com/terms/datastax-labs-terms]
+
+-->
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d %5p | %t | %-55logger{55} | %m | %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.springframework" level="ERROR" />
+    <logger name="com.datastax" level="ERROR" />
+
+    <logger name="com.datastax.oss.spring" level="INFO" />
+
+    <root level="ERROR">
+        <appender-ref ref="console" />
+    </root>
+
+</configuration>

--- a/spring-boot-starter/README.md
+++ b/spring-boot-starter/README.md
@@ -1,0 +1,10 @@
+# DataStax Java Driver Spring Boot Starter Labs
+
+Each release of the DataStax Java Driver Spring Boot Starter Labs
+preview is listed below. Choose the appropriate path for the labs
+version you are using, or choose the newest version if you are just
+getting started.
+
+| Version | Date Released | Notes |
+| ------- | ------------- | ----- |
+| [20190903](./20190903) | 2019-09-03 | First preview release demonstrating Starter usage |


### PR DESCRIPTION
Temporarily bring back the spring-boot-starter directory until the Pivotal/VMWare Spring Boot Starter for Cassandra is released. That starter is currently in [milestone 4 of the 2.3.0 release](https://github.com/spring-projects/spring-boot/releases/tag/v2.3.0.M4).